### PR TITLE
Updated Logger

### DIFF
--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -17,8 +17,40 @@ static std::string getCurrentDateTime() {
 	return std::string(current_time);
 }
 
-void Logger::baseLog(e_logger_lvl lvl, const std::string& msg) {
+// TODO: if possible better optimized code
+// TODO: adding a format for ip addresses to show in color
+std::string Logger::formatLog(const std::string& msg) {
+	std::string output = msg;
+	std::size_t pos = 0;
+
+	while ((pos = output.find("http://", pos)) != std::string::npos) {
+		std::size_t end = output.find_first_of(" \t\n", pos);
+		if (end == std::string::npos) {
+			end = output.length();
+		}
+		std::string url = output.substr(pos, end - pos);
+		std::string colored_url = std::string(C_CYAN) + C_UNDERLINE + url + C_RESET;
+		output.replace(pos, url.length(), colored_url);
+		pos += colored_url.length();
+	}
+
+	pos = 0;
+	while ((pos = output.find("https://", pos)) != std::string::npos) {
+		std::size_t end = output.find_first_of(" \t\n", pos);
+		if (end == std::string::npos) {
+			end = output.length();
+		}
+		std::string url = output.substr(pos, end - pos);
+		std::string colored_url = std::string(C_CYAN) + C_UNDERLINE + url + C_RESET;
+		output.replace(pos, url.length(), colored_url);
+		pos += colored_url.length();
+	}
+	return output;
+}
+
+std::ostream& Logger::baseLog(e_logger_lvl lvl, const std::string& msg) {
 	std::ostream& stream = lvl <= 2 ? std::cerr : std::cout;
+
 	stream << "[" << getCurrentDateTime() << "] ";
 	switch(lvl) {
 		case LFATAL:
@@ -37,26 +69,29 @@ void Logger::baseLog(e_logger_lvl lvl, const std::string& msg) {
 			stream << C_PINK << "[DEBUG]";
 			break;
 	}
-	stream << C_RESET << " " << msg << std::endl;
+	stream << C_RESET << " " << formatLog(msg);
+	return stream;
 }
 
-void Logger::fatal(const std::string& str) {
-	Logger::baseLog(LFATAL, str);
+std::ostream& Logger::fatal(const std::string& str) {
+	return Logger::baseLog(LFATAL, str);
 }
 
-void Logger::error(const std::string& str) {
-	Logger::baseLog(LERROR, str);
+std::ostream& Logger::error(const std::string& str) {
+	return Logger::baseLog(LERROR, str);
 }
 
-void Logger::warning(const std::string& str) {
-	Logger::baseLog(LWARNING, str);
+std::ostream& Logger::warning(const std::string& str) {
+	return Logger::baseLog(LWARNING, str);
 }
 
-void Logger::info(const std::string& str) {
-	Logger::baseLog(LINFO, str);
+std::ostream& Logger::info(const std::string& str) {
+	return Logger::baseLog(LINFO, str);
 }
 
-void Logger::debug(const std::string& str) {
+std::ostream& Logger::debug(const std::string& str) {
 	if (LOGGER_DEBUG)
-		Logger::baseLog(LDEBUG, str);
+		return Logger::baseLog(LDEBUG, str);
+	else
+		return std::cout;
 }

--- a/src/utils/Logger.hpp
+++ b/src/utils/Logger.hpp
@@ -27,14 +27,15 @@ class Logger {
 		Logger(const Logger&) {};
 		Logger& operator=(const Logger&) {return *this;};
 		~Logger() {};
-		static void baseLog(e_logger_lvl lvl, const std::string& msg);
+		static std::ostream& baseLog(e_logger_lvl lvl, const std::string&);
+		static std::string formatLog(const std::string&);
 
 	public:
-		static void fatal(const std::string&);
-		static void error(const std::string&);
-		static void warning(const std::string&);
-		static void info(const std::string&);
-		static void debug(const std::string&);
+		static std::ostream& fatal(const std::string&);
+		static std::ostream& error(const std::string&);
+		static std::ostream& warning(const std::string&);
+		static std::ostream& info(const std::string&);
+		static std::ostream& debug(const std::string&);
 };
 
 #endif


### PR DESCRIPTION
Logger functions will no longer print std::endl themselves; the user can now use the stream returned by the function to either continue the stream or finish it.

e.g.
```c++
Logger::fatal("CoreManager:") << strerror(errno) << std::endl;
```