### PR TITLE
Fix initialization of fileStream in s_clientBuffer constructor

### DIFF
--- a/src/classes/ClientHandler.hpp
+++ b/src/classes/ClientHandler.hpp
@@ -36,7 +36,7 @@ struct s_clientBuffer {
 	std::ifstream fileStream;
 	s_clientBuffer():
 		requestBuffer(0),
-		fileStream(0) {}
+		fileStream() {}
 };
 
 // Unique client address identifier


### PR DESCRIPTION
- bug fix:
  - default filestream constructor for client throwing an error because of null string: now using default constructor