### PR TITLE
Http server

### DIFF
--- a/src/classes/ClientHandler.cpp
+++ b/src/classes/ClientHandler.cpp
@@ -223,19 +223,19 @@ const HttpResponse& ClientHandler::buildResponse(HttpResponse response) {
 			}
 		}
 	} else {
-		// Handle delete method
 		if (this->request_.getMethod() == "DELETE") {
 			if (this->buffer_.externalBody.is_open())
 				this->buffer_.externalBody.close();
-			if (unlink(rootFile.c_str()) < 0) {
+			if (unlink(rootFile.c_str()) < 0)
 				return this->buildResponse(HttpResponse(this->request_, 404));
-			}
 			response.setStatus(204);
 		} else if (this->request_.getMethod() == "POST") {
 			try{
 				request_.buildBody(matchingRoot->getFinalPath(), matchingRoot->getUploadPath());
+				response.setStatus(201);
 			}
-			catch (const std::exception &e){
+			catch (const std::exception &e) {
+				this->error("POST: ") << e.what() << std::endl;
 				return buildResponse(HttpResponse(request_, 500));
 			}
 		}
@@ -255,8 +255,7 @@ const HttpResponse& ClientHandler::buildResponse(HttpResponse response) {
 			}
 		}
 		catch(const std::exception& e) {
-			std::string	errMessage = e.what() ;
-			Logger::error("CGI Error: " + errMessage + "\n") ;
+			Logger::error("CGI Error: ") << e.what() << std::endl;
 			return buildResponse(HttpResponse(this->request_, 500));
 		}
 	}

--- a/src/classes/ListingBuilder.cpp
+++ b/src/classes/ListingBuilder.cpp
@@ -8,10 +8,11 @@ ListingBuilder::~ListingBuilder() {}
 std::string ListingBuilder::buildBody(const std::string& url, const std::string& file) {
 	std::string body;
 
+	std::string parsedUrl = url.at(url.length() - 1) == '/' ? url.substr(0, url.length() - 1) : url;
 	DIR *dir;
 	dir = opendir(file.c_str());
 	if (!dir) throw std::runtime_error(EXC_NO_DIR);
-	body.append("<html><head><title>Index of " + url + "</title></head><body><h1>Index of " + url + "</h1><hr><pre>");
+	body.append("<html><head><title>Index of " + parsedUrl + "</title></head><body><h1>Index of " + parsedUrl + "</h1><hr><pre>");
 	struct dirent *entry;
 	std::map<std::string, dirent *> files;
 	while ((entry = readdir(dir))) {
@@ -23,7 +24,7 @@ std::string ListingBuilder::buildBody(const std::string& url, const std::string&
 			files[entry->d_name] = entry;
 	}
 	for(std::map<std::string, dirent *>::const_iterator it = files.begin(); it != files.end(); it++) {
-		body.append("<a href=\"" + std::string(it->first) + "\">" + std::string(it->first) + "</a><br>");
+		body.append("<a href=\"" + parsedUrl + "/" + std::string(it->first) + "\">" + std::string(it->first) + "</a><br>");
 	}
 	body.append("</pre><hr></body></html>");
 	return body;

--- a/src/classes/Runtime.cpp
+++ b/src/classes/Runtime.cpp
@@ -209,14 +209,12 @@ int Runtime::handleClientPollin_(ClientHandler *client, pollfd *socket) {
 			client->readSocket();
 		} catch (const std::exception& e) {
 			client->buildResponse(HttpResponse(client->getRequest(), 500));
-			#if LOGGER_DEBUG
-				this->debug("client ") << client->getFd() << ": " << e.what() << std::endl;
-			#endif
+			this->error("client ") << client->getFd() << ": " << e.what() << std::endl;
 			return 1;
 		}
 		client->updateLastAlive();
 	} else {
-		if (client->getFlags() & READING || client->getFlags() & FETCHED) {
+		if (client->getFlags() & READING) {
 			socket->events = POLLOUT | POLLHUP;
 			#if LOGGER_DEBUG
 				this->debug("pollin end client (fd: ") << client->getFd() << ")" << std::endl;
@@ -225,6 +223,7 @@ int Runtime::handleClientPollin_(ClientHandler *client, pollfd *socket) {
 				client->buildRequest();
 				this->handleRequest_(client);
 			} catch (const std::exception& e) {
+				this->error(e.what()) << std::endl;
 				std::string exception(e.what());
 				
 				if (exception == EXC_NOT_VALID_SERVERNAME) {


### PR DESCRIPTION
- Fixed runtime issue the same Request -> it only a visual effect and had no impact clients
- More errors are printed in catch -> some catches did not have any logger or using Logger::debug, forcing us to debug to see what was happening. Now errors will be printed in std::cerr at the Error level
- Fixed issue #40
