### PR TITLE
body too large memory saver

### DIFF
--- a/src/classes/ClientHandler.hpp
+++ b/src/classes/ClientHandler.hpp
@@ -34,6 +34,9 @@
 # define SENT 0x02 // Response sent
 # define SENDING 0x04 // Still sending response
 # define RESPONSE 0x8 // Has a response
+# define ERR_BODYTOOBIG 0x10 // Error body size
+# define ERR_NOLENGTH 0x20 // Error no content-length
+# define THROWING 0x30 // Readsocket will throw after reading the header
 
 
 class Runtime;

--- a/src/classes/ServerManager.cpp
+++ b/src/classes/ServerManager.cpp
@@ -22,6 +22,7 @@ static sockaddr_in newAddr(int port, std::string interface) {
 }
 
 void ServerManager::init() {
+	this->maxBody_ = this->config_.getClientBodyLimit();
 	this->server_fd_ = socket(AF_INET, SOCK_STREAM, 0);
 
 	if (this->server_fd_ < 0) { throw std::logic_error("server_fd_ socket: " + std::string(strerror(errno))); }
@@ -41,7 +42,8 @@ ServerManager::ServerManager(const ServerConfig& config):
 	addrv4_(newAddr(config.getPort(), config.getHost())),
 	address_((sockaddr *)&this->addrv4_),
 	routeconfig_(config.getRoutes()),
-	server_fd_(-1) {}
+	server_fd_(-1),
+	maxBody_(0) {}
 
 ServerManager::ServerManager(const ServerManager& copy):
 	config_(copy.config_),
@@ -49,7 +51,8 @@ ServerManager::ServerManager(const ServerManager& copy):
 	address_((sockaddr *)&this->addrv4_),
 	routeconfig_(copy.routeconfig_),
 	server_fd_(copy.server_fd_),
-	socket_(copy.socket_) {}
+	socket_(copy.socket_),
+	maxBody_(copy.maxBody_) {}
 
 ServerManager& ServerManager::operator=(const ServerManager& assign) {
 	if (this == &assign)
@@ -70,3 +73,5 @@ const ServerConfig& ServerManager::getConfig() const { return this->config_; }
 const std::vector<RouteConfig>& ServerManager::getRouteConfig() const { return this->routeconfig_; }
 std::vector<ServerManager *>& ServerManager::getVirtualHosts() { return this->virtualHosts_; }
 const std::vector<ServerManager *>& ServerManager::getVirtualHosts() const { return this->virtualHosts_; }
+unsigned long long ServerManager::getMaxBody() const { return this->maxBody_; }
+void ServerManager::updateMaxBody(unsigned long long value) { if(value > this->maxBody_) this->maxBody_ = value; }

--- a/src/classes/ServerManager.hpp
+++ b/src/classes/ServerManager.hpp
@@ -39,6 +39,7 @@ class ServerManager {
 		std::vector<ServerManager *> virtualHosts_;
 		int server_fd_;
 		pollfd socket_;
+		unsigned long long maxBody_;
 
 	public:
 		// Canonical
@@ -59,6 +60,10 @@ class ServerManager {
 		const std::vector<RouteConfig>& getRouteConfig() const;
 		std::vector<ServerManager *>& getVirtualHosts();
 		const std::vector<ServerManager *>& getVirtualHosts() const;
+		// Get the biggest body limit from virtual hosts
+		unsigned long long getMaxBody() const;
+		// Will update maxBody_ if new value is bigger
+		void updateMaxBody(unsigned long long);
 };
 
 #endif


### PR DESCRIPTION
- fix: some logs were not correct
- feat: prevent server from buffering socket data if body limit exceeded


while fixing:
- #76 

i removed the feature where client would flush it's body memory and ignore the reads from clients when he detects that the body was too large

i had to because i could not get bodyLimit from client config, since he has to parse the request before knowing which virtual host he should use

i fixed that by adding adding a variable to the hostServer (the main server) containing the biggest bodyLimit from its virtualServers

clients can now use this value to determine if the body is too large while reading the socket

it shouldn't break since it's the same feature as before but with extra steps